### PR TITLE
Optimized calls to getComputedStyle

### DIFF
--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -38,7 +38,8 @@ function ellipsed() {
       var textBeforeWrap = '';
 
       el.textContent = '';
-      var elHeight = window.getComputedStyle(el).height;
+      var elStyle = window.getComputedStyle(el);
+      var elHeight = elStyle.height;
 
       var _iteratorNormalCompletion2 = true;
       var _didIteratorError2 = false;
@@ -54,8 +55,8 @@ function ellipsed() {
             el.textContent = '' + el.textContent + token + '...';
           }
 
-          if (parseFloat(window.getComputedStyle(el).height) > parseFloat(elHeight)) {
-            elHeight = window.getComputedStyle(el).height;
+          if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
+            elHeight = elStyle.height;
             rowsWrapped++;
 
             if (rowsWrapped === rows + 1) {

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -26,7 +26,8 @@ function ellipsed(selector = '', rows = 1) {
     let textBeforeWrap = '';
 
     el.textContent = '';
-    let elHeight = window.getComputedStyle(el).height;
+    const elStyle = window.getComputedStyle(el);
+    let elHeight = elStyle.height;
 
     for (const token of splittedText) {
       if (el.textContent.length) {
@@ -35,8 +36,8 @@ function ellipsed(selector = '', rows = 1) {
         el.textContent = `${el.textContent}${token}...`;
       }
 
-      if (parseFloat(window.getComputedStyle(el).height) > parseFloat(elHeight)) {
-        elHeight = window.getComputedStyle(el).height;
+      if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
+        elHeight = elStyle.height;
         rowsWrapped++;
 
         if (rowsWrapped === rows + 1) {


### PR DESCRIPTION
From the [MDN docs on Window.getComputedStyle](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#Syntax):
>The returned style is a live CSSStyleDeclaration object, which updates itself automatically when the element's style is changed.

This PR changes the source code so that it calls `getComputedStyle` just once and then retrieves the width whenever needed.