### PR TITLE
Changed default export to named export. Some other minor cleanup.

### DIFF
--- a/example/index.css
+++ b/example/index.css
@@ -1,4 +1,4 @@
-* {
+body {
     font-family: 'Arial', sans-serif;
 }
 
@@ -39,6 +39,7 @@ h1 {
     border-radius: 5px;
     background: #fff;
     border: 1px solid #bbb;
+    cursor: pointer;
 }
 
 .btn:hover {

--- a/example/index.js
+++ b/example/index.js
@@ -1,36 +1,36 @@
-const ellipsed = window.ellipsed.default;
+var ellipsis = window.ellipsed.ellipsis;
 
-const reset = () => {
-  let aaa = document.querySelectorAll('.text p')[0];
+function reset() {
+  var aaa = document.querySelectorAll('.text p')[0];
 
-  let loremIpsum = document.querySelectorAll('.text p')[1];
+  var loremIpsum = document.querySelectorAll('.text p')[1];
 
   aaa.innerText = 'A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a';
 
   loremIpsum.innerText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis lorem ut libero malesuada feugiat. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Pellentesque in ipsum id orci porta dapibus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed porttitor lectus nibh. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
-};
+}
 
-const uno = () => {
+function uno() {
   reset();
-  ellipsed('.text p', 1);
-};
+  ellipsis('.text p', 1);
+}
 
-const due = () => {
+function due() {
   reset();
-  ellipsed('.text p', 2);
-};
+  ellipsis('.text p', 2);
+}
 
-const tre = () => {
+function tre() {
   reset();
-  ellipsed('.text p', 3);
-};
+  ellipsis('.text p', 3);
+}
 
-const quattro = () => {
+function quattro() {
   reset();
-  ellipsed('.text p', 4);
-};
+  ellipsis('.text p', 4);
+}
 
-const cinque = () => {
+function cinque() {
   reset();
-  ellipsed('.text p', 5);
-};
+  ellipsis('.text p', 5);
+}

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -16,28 +16,28 @@
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-  function ellipsed() {
+  /*   Copyright (C) 2017  Nicola Zambello
+   *
+   *    https://github.com/nzambello/ellipsed
+   *
+   *    The JavaScript code in this page is free software: you can
+   *    redistribute it and/or modify it under the terms of the GNU
+   *    General Public License (GNU GPL) as published by the Free Software
+   *    Foundation, either version 3 of the License, or (at your option)
+   *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
+   *    without even the implied warranty of MERCHANTABILITY or FITNESS
+   *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
+   *
+   *    As additional permission under GNU GPL version 3 section 7, you
+   *    may distribute non-source (e.g., minimized or compacted) forms of
+   *    that code without the copy of the GNU GPL normally required by
+   *    section 4, provided you include this license notice and a URL
+   *    through which recipients can access the Corresponding Source.
+   */
+
+  function ellipsis() {
     var selector = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
     var rows = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
-
-    /*   Copyright (C) 2017  Nicola Zambello
-     *
-     *    https://github.com/nzambello/ellipsed
-     *
-     *    The JavaScript code in this page is free software: you can
-     *    redistribute it and/or modify it under the terms of the GNU
-     *    General Public License (GNU GPL) as published by the Free Software
-     *    Foundation, either version 3 of the License, or (at your option)
-     *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
-     *    without even the implied warranty of MERCHANTABILITY or FITNESS
-     *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
-     *
-     *    As additional permission under GNU GPL version 3 section 7, you
-     *    may distribute non-source (e.g., minimized or compacted) forms of
-     *    that code without the copy of the GNU GPL normally required by
-     *    section 4, provided you include this license notice and a URL
-     *    through which recipients can access the Corresponding Source.
-     */
 
     var elements = document.querySelectorAll(selector);
 
@@ -68,7 +68,7 @@
             if (el.textContent.length) {
               el.textContent = el.textContent + ' ' + token + '...';
             } else {
-              el.textContent = '' + el.textContent + token + '...';
+              el.textContent = token + '...';
             }
 
             if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
@@ -82,7 +82,7 @@
               }
             }
 
-            textBeforeWrap = textBeforeWrap.length ? textBeforeWrap + ' ' + token : '' + textBeforeWrap + token;
+            textBeforeWrap = textBeforeWrap.length ? textBeforeWrap + ' ' + token : '' + token;
             el.textContent = textBeforeWrap;
           }
         } catch (err) {
@@ -116,5 +116,5 @@
     }
   }
 
-  exports.default = ellipsed;
+  exports.ellipsis = ellipsis;
 });

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -1,23 +1,23 @@
-function ellipsed(selector = '', rows = 1) {
-  /*   Copyright (C) 2017  Nicola Zambello
-   *
-   *    https://github.com/nzambello/ellipsed
-   *
-   *    The JavaScript code in this page is free software: you can
-   *    redistribute it and/or modify it under the terms of the GNU
-   *    General Public License (GNU GPL) as published by the Free Software
-   *    Foundation, either version 3 of the License, or (at your option)
-   *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
-   *    without even the implied warranty of MERCHANTABILITY or FITNESS
-   *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
-   *
-   *    As additional permission under GNU GPL version 3 section 7, you
-   *    may distribute non-source (e.g., minimized or compacted) forms of
-   *    that code without the copy of the GNU GPL normally required by
-   *    section 4, provided you include this license notice and a URL
-   *    through which recipients can access the Corresponding Source.
-   */
+/*   Copyright (C) 2017  Nicola Zambello
+ *
+ *    https://github.com/nzambello/ellipsed
+ *
+ *    The JavaScript code in this page is free software: you can
+ *    redistribute it and/or modify it under the terms of the GNU
+ *    General Public License (GNU GPL) as published by the Free Software
+ *    Foundation, either version 3 of the License, or (at your option)
+ *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
+ *    without even the implied warranty of MERCHANTABILITY or FITNESS
+ *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
+ *
+ *    As additional permission under GNU GPL version 3 section 7, you
+ *    may distribute non-source (e.g., minimized or compacted) forms of
+ *    that code without the copy of the GNU GPL normally required by
+ *    section 4, provided you include this license notice and a URL
+ *    through which recipients can access the Corresponding Source.
+ */
 
+function ellipsis(selector = '', rows = 1) {
   const elements = document.querySelectorAll(selector);
 
   for (const el of elements) {
@@ -33,7 +33,7 @@ function ellipsed(selector = '', rows = 1) {
       if (el.textContent.length) {
         el.textContent = `${el.textContent} ${token}...`;
       } else {
-        el.textContent = `${el.textContent}${token}...`;
+        el.textContent = `${token}...`;
       }
 
       if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
@@ -51,10 +51,10 @@ function ellipsed(selector = '', rows = 1) {
 
       textBeforeWrap = textBeforeWrap.length
         ? `${textBeforeWrap} ${token}`
-        : `${textBeforeWrap}${token}`;
+        : `${token}`;
       el.textContent = textBeforeWrap;
     }
   }
 }
 
-export default ellipsed;
+export { ellipsis };


### PR DESCRIPTION
Prefer named export, plus some minor code cleanup.
The library is now officially named `ellipsed` and exports the function `ellipsis`. The logic is unchanged.

**This is a breaking change and should probably go in a 0.3.x release.**