### PR TITLE
Removed for..of for browser compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,8 @@
         "modules": "umd"
       }
     ]
+  ],
+  "plugins": [
+    "transform-object-rest-spread"
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,10 @@
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "sourceType": "module"
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "experimentalObjectRestSpread": true
+        }
     },
     "rules": {
         "indent": [

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -44,6 +44,7 @@
   function tokensReducer(acc, token) {
     var el = acc.el,
         elStyle = acc.elStyle,
+        elHeight = acc.elHeight,
         rowsLimit = acc.rowsLimit,
         rowsWrapped = acc.rowsWrapped;
 
@@ -51,23 +52,24 @@
       return _extends({}, acc);
     }
     var textBeforeWrap = el.textContent;
-    var elHeight = elStyle.height;
     var newRowsWrapped = rowsWrapped;
+    var newHeight = elHeight;
     el.textContent = el.textContent.length ? el.textContent + ' ' + token + '...' : token + '...';
 
     if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
       newRowsWrapped++;
+      newHeight = elStyle.height;
 
       if (newRowsWrapped === rowsLimit + 1) {
-        el.textContent = textBeforeWrap[textBeforeWrap.length - 1] === '.' ? textBeforeWrap + '..' : textBeforeWrap + '...';
+        el.innerHTML = textBeforeWrap[textBeforeWrap.length - 1] === '.' ? textBeforeWrap + '..' : textBeforeWrap + '...';
 
-        return _extends({}, acc, { rowsWrapped: newRowsWrapped });
+        return _extends({}, acc, { elHeight: newHeight, rowsWrapped: newRowsWrapped });
       }
     }
 
     el.textContent = textBeforeWrap.length ? textBeforeWrap + ' ' + token : '' + token;
 
-    return _extends({}, acc, { rowsWrapped: newRowsWrapped });
+    return _extends({}, acc, { elHeight: newHeight, rowsWrapped: newRowsWrapped });
   }
 
   function ellipsis() {
@@ -76,63 +78,20 @@
 
     var elements = document.querySelectorAll(selector);
 
-    var _iteratorNormalCompletion = true;
-    var _didIteratorError = false;
-    var _iteratorError = undefined;
+    for (var i = 0; i < elements.length; ++i) {
+      var el = elements[i];
+      var splittedText = el.textContent.split(' ');
 
-    try {
-      for (var _iterator = elements[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-        var el = _step.value;
+      el.textContent = '';
+      var elStyle = window.getComputedStyle(el);
 
-        var splittedText = el.textContent.split(' ');
-        // let rowsWrapped = 0;
-        // let textBeforeWrap = '';
-
-        el.textContent = '';
-        var elStyle = window.getComputedStyle(el);
-        // let elHeight = elStyle.height;
-
-        splittedText.reduce(tokensReducer, {
-          el: el,
-          elStyle: elStyle,
-          rowsLimit: rows,
-          rowsWrapped: 0
-        });
-        /* for (const token of splittedText) {
-          if (el.textContent.length) {
-            el.textContent = `${el.textContent} ${token}...`;
-          } else {
-            el.textContent = `${token}...`;
-          }
-           if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
-            elHeight = elStyle.height;
-            rowsWrapped++;
-             if (rowsWrapped === rows + 1) {
-              el.innerHTML = textBeforeWrap[textBeforeWrap.length - 1] === '.'
-                ? `${textBeforeWrap}..`
-                : `${textBeforeWrap}...`;
-               break;
-            }
-          }
-           textBeforeWrap = textBeforeWrap.length
-            ? `${textBeforeWrap} ${token}`
-            : `${token}`;
-          el.textContent = textBeforeWrap;
-        } */
-      }
-    } catch (err) {
-      _didIteratorError = true;
-      _iteratorError = err;
-    } finally {
-      try {
-        if (!_iteratorNormalCompletion && _iterator.return) {
-          _iterator.return();
-        }
-      } finally {
-        if (_didIteratorError) {
-          throw _iteratorError;
-        }
-      }
+      splittedText.reduce(tokensReducer, {
+        el: el,
+        elStyle: elStyle,
+        elHeight: 0,
+        rowsLimit: rows,
+        rowsWrapped: 0
+      });
     }
   }
 

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -16,28 +16,72 @@
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
+
+  var _extends = Object.assign || function (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+
+    return target;
+  };
+
+  /*   Copyright (C) 2017  Nicola Zambello
+    *
+    *    https://github.com/nzambello/ellipsed
+    *
+    *    The JavaScript code in this page is free software: you can
+    *    redistribute it and/or modify it under the terms of the GNU
+    *    General Public License (GNU GPL) as published by the Free Software
+    *    Foundation, either version 3 of the License, or (at your option)
+    *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
+    *    without even the implied warranty of MERCHANTABILITY or FITNESS
+    *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
+    *
+    *    As additional permission under GNU GPL version 3 section 7, you
+    *    may distribute non-source (e.g., minimized or compacted) forms of
+    *    that code without the copy of the GNU GPL normally required by
+    *    section 4, provided you include this license notice and a URL
+    *    through which recipients can access the Corresponding Source.
+    */
+
+  function tokensReducer(acc, token) {
+    var el = acc.el,
+        elStyle = acc.elStyle,
+        rowsLimit = acc.rowsLimit,
+        rowsWrapped = acc.rowsWrapped;
+
+    if (rowsWrapped === rowsLimit + 1) {
+      return _extends({}, acc);
+    }
+    var textBeforeWrap = el.textContent;
+    var elHeight = elStyle.height;
+    var newRowsWrapped = rowsWrapped;
+    el.textContent = el.textContent.length ? el.textContent + ' ' + token + '...' : token + '...';
+
+    if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
+      newRowsWrapped++;
+
+      if (newRowsWrapped === rowsLimit + 1) {
+        el.textContent = textBeforeWrap[textBeforeWrap.length - 1] === '.' ? textBeforeWrap + '..' : textBeforeWrap + '...';
+
+        return _extends({}, acc, { rowsWrapped: newRowsWrapped });
+      }
+    }
+
+    el.textContent = textBeforeWrap.length ? textBeforeWrap + ' ' + token : '' + token;
+
+    return _extends({}, acc, { rowsWrapped: newRowsWrapped });
+  }
+
   function ellipsed() {
     var selector = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
     var rows = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
-
-    /*   Copyright (C) 2017  Nicola Zambello
-     *
-     *    https://github.com/nzambello/ellipsed
-     *
-     *    The JavaScript code in this page is free software: you can
-     *    redistribute it and/or modify it under the terms of the GNU
-     *    General Public License (GNU GPL) as published by the Free Software
-     *    Foundation, either version 3 of the License, or (at your option)
-     *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
-     *    without even the implied warranty of MERCHANTABILITY or FITNESS
-     *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
-     *
-     *    As additional permission under GNU GPL version 3 section 7, you
-     *    may distribute non-source (e.g., minimized or compacted) forms of
-     *    that code without the copy of the GNU GPL normally required by
-     *    section 4, provided you include this license notice and a URL
-     *    through which recipients can access the Corresponding Source.
-     */
 
     var elements = document.querySelectorAll(selector);
 
@@ -50,55 +94,40 @@
         var el = _step.value;
 
         var splittedText = el.textContent.split(' ');
-        var rowsWrapped = 0;
-        var textBeforeWrap = '';
+        // let rowsWrapped = 0;
+        // let textBeforeWrap = '';
 
         el.textContent = '';
         var elStyle = window.getComputedStyle(el);
-        var elHeight = elStyle.height;
+        // let elHeight = elStyle.height;
 
-        var _iteratorNormalCompletion2 = true;
-        var _didIteratorError2 = false;
-        var _iteratorError2 = undefined;
-
-        try {
-          for (var _iterator2 = splittedText[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-            var token = _step2.value;
-
-            if (el.textContent.length) {
-              el.textContent = el.textContent + ' ' + token + '...';
-            } else {
-              el.textContent = '' + el.textContent + token + '...';
-            }
-
-            if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
-              elHeight = elStyle.height;
-              rowsWrapped++;
-
-              if (rowsWrapped === rows + 1) {
-                el.innerHTML = textBeforeWrap[textBeforeWrap.length - 1] === '.' ? textBeforeWrap + '..' : textBeforeWrap + '...';
-
-                break;
-              }
-            }
-
-            textBeforeWrap = textBeforeWrap.length ? textBeforeWrap + ' ' + token : '' + textBeforeWrap + token;
-            el.textContent = textBeforeWrap;
+        splittedText.reduce(tokensReducer, {
+          el: el,
+          elStyle: elStyle,
+          rowsLimit: rows,
+          rowsWrapped: 0
+        });
+        /* for (const token of splittedText) {
+          if (el.textContent.length) {
+            el.textContent = `${el.textContent} ${token}...`;
+          } else {
+            el.textContent = `${el.textContent}${token}...`;
           }
-        } catch (err) {
-          _didIteratorError2 = true;
-          _iteratorError2 = err;
-        } finally {
-          try {
-            if (!_iteratorNormalCompletion2 && _iterator2.return) {
-              _iterator2.return();
-            }
-          } finally {
-            if (_didIteratorError2) {
-              throw _iteratorError2;
+           if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
+            elHeight = elStyle.height;
+            rowsWrapped++;
+             if (rowsWrapped === rows + 1) {
+              el.innerHTML = textBeforeWrap[textBeforeWrap.length - 1] === '.'
+                ? `${textBeforeWrap}..`
+                : `${textBeforeWrap}...`;
+               break;
             }
           }
-        }
+           textBeforeWrap = textBeforeWrap.length
+            ? `${textBeforeWrap} ${token}`
+            : `${textBeforeWrap}${token}`;
+          el.textContent = textBeforeWrap;
+        } */
       }
     } catch (err) {
       _didIteratorError = true;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "lib/ellipsed.js",
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "eslint": "^4.6.1",
     "serve": "^6.0.6"

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -1,35 +1,75 @@
-function ellipsed(selector = '', rows = 1) {
-  /*   Copyright (C) 2017  Nicola Zambello
-   *
-   *    https://github.com/nzambello/ellipsed
-   *
-   *    The JavaScript code in this page is free software: you can
-   *    redistribute it and/or modify it under the terms of the GNU
-   *    General Public License (GNU GPL) as published by the Free Software
-   *    Foundation, either version 3 of the License, or (at your option)
-   *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
-   *    without even the implied warranty of MERCHANTABILITY or FITNESS
-   *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
-   *
-   *    As additional permission under GNU GPL version 3 section 7, you
-   *    may distribute non-source (e.g., minimized or compacted) forms of
-   *    that code without the copy of the GNU GPL normally required by
-   *    section 4, provided you include this license notice and a URL
-   *    through which recipients can access the Corresponding Source.
-   */
+/*   Copyright (C) 2017  Nicola Zambello
+  *
+  *    https://github.com/nzambello/ellipsed
+  *
+  *    The JavaScript code in this page is free software: you can
+  *    redistribute it and/or modify it under the terms of the GNU
+  *    General Public License (GNU GPL) as published by the Free Software
+  *    Foundation, either version 3 of the License, or (at your option)
+  *    any later version.  The code is distributed WITHOUT ANY WARRANTY;
+  *    without even the implied warranty of MERCHANTABILITY or FITNESS
+  *    FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
+  *
+  *    As additional permission under GNU GPL version 3 section 7, you
+  *    may distribute non-source (e.g., minimized or compacted) forms of
+  *    that code without the copy of the GNU GPL normally required by
+  *    section 4, provided you include this license notice and a URL
+  *    through which recipients can access the Corresponding Source.
+  */
 
+function tokensReducer(acc, token) {
+  const { el, elStyle, rowsLimit, rowsWrapped } = acc;
+  if (rowsWrapped === rowsLimit + 1) {
+    return { ...acc };
+  }
+  const textBeforeWrap = el.textContent;
+  const elHeight = elStyle.height;
+  let newRowsWrapped = rowsWrapped;
+  el.textContent = el.textContent.length
+    ? `${el.textContent} ${token}...`
+    : `${token}...`;
+
+  if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
+    newRowsWrapped++;
+
+    if (newRowsWrapped === rowsLimit + 1) {
+      el.textContent = textBeforeWrap[textBeforeWrap.length - 1] === '.'
+        ? `${textBeforeWrap}..`
+        : `${textBeforeWrap}...`;
+      
+      return { ...acc, rowsWrapped: newRowsWrapped };
+    }
+  }
+
+  el.textContent = textBeforeWrap.length
+    ? `${textBeforeWrap} ${token}`
+    : `${token}`;
+
+  return { ...acc, rowsWrapped: newRowsWrapped };
+}
+
+function ellipsed(selector = '', rows = 1) {
   const elements = document.querySelectorAll(selector);
 
   for (const el of elements) {
     const splittedText = el.textContent.split(' ');
-    let rowsWrapped = 0;
-    let textBeforeWrap = '';
+    // let rowsWrapped = 0;
+    // let textBeforeWrap = '';
 
     el.textContent = '';
     const elStyle = window.getComputedStyle(el);
-    let elHeight = elStyle.height;
+    // let elHeight = elStyle.height;
 
-    for (const token of splittedText) {
+    splittedText.reduce(
+      tokensReducer,
+      {
+        el,
+        elStyle,
+        rowsLimit: rows,
+        rowsWrapped: 0,
+      }
+    );
+    /* for (const token of splittedText) {
       if (el.textContent.length) {
         el.textContent = `${el.textContent} ${token}...`;
       } else {
@@ -53,7 +93,7 @@ function ellipsed(selector = '', rows = 1) {
         ? `${textBeforeWrap} ${token}`
         : `${textBeforeWrap}${token}`;
       el.textContent = textBeforeWrap;
-    }
+    } */
   }
 }
 

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -9,26 +9,27 @@
  */
 
 function tokensReducer(acc, token) {
-  const { el, elStyle, rowsLimit, rowsWrapped } = acc;
+  const { el, elStyle, elHeight, rowsLimit, rowsWrapped } = acc;
   if (rowsWrapped === rowsLimit + 1) {
     return { ...acc };
   }
   const textBeforeWrap = el.textContent;
-  const elHeight = elStyle.height;
   let newRowsWrapped = rowsWrapped;
+  let newHeight = elHeight;
   el.textContent = el.textContent.length
     ? `${el.textContent} ${token}...`
     : `${token}...`;
 
   if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
     newRowsWrapped++;
+    newHeight = elStyle.height;
 
     if (newRowsWrapped === rowsLimit + 1) {
-      el.textContent = textBeforeWrap[textBeforeWrap.length - 1] === '.'
+      el.innerHTML = textBeforeWrap[textBeforeWrap.length - 1] === '.'
         ? `${textBeforeWrap}..`
         : `${textBeforeWrap}...`;
-      
-      return { ...acc, rowsWrapped: newRowsWrapped };
+
+      return { ...acc, elHeight: newHeight, rowsWrapped: newRowsWrapped };
     }
   }
 
@@ -36,55 +37,29 @@ function tokensReducer(acc, token) {
     ? `${textBeforeWrap} ${token}`
     : `${token}`;
 
-  return { ...acc, rowsWrapped: newRowsWrapped };
+  return { ...acc, elHeight: newHeight, rowsWrapped: newRowsWrapped };
 }
 
 function ellipsis(selector = '', rows = 1) {
   const elements = document.querySelectorAll(selector);
 
-  for (const el of elements) {
+  for(let i = 0; i < elements.length; ++i) {
+    const el = elements[i];
     const splittedText = el.textContent.split(' ');
-    // let rowsWrapped = 0;
-    // let textBeforeWrap = '';
 
     el.textContent = '';
     const elStyle = window.getComputedStyle(el);
-    // let elHeight = elStyle.height;
 
     splittedText.reduce(
       tokensReducer,
       {
         el,
         elStyle,
+        elHeight: 0,
         rowsLimit: rows,
         rowsWrapped: 0,
       }
     );
-    /* for (const token of splittedText) {
-      if (el.textContent.length) {
-        el.textContent = `${el.textContent} ${token}...`;
-      } else {
-        el.textContent = `${token}...`;
-      }
-
-      if (parseFloat(elStyle.height) > parseFloat(elHeight)) {
-        elHeight = elStyle.height;
-        rowsWrapped++;
-
-        if (rowsWrapped === rows + 1) {
-          el.innerHTML = textBeforeWrap[textBeforeWrap.length - 1] === '.'
-            ? `${textBeforeWrap}..`
-            : `${textBeforeWrap}...`;
-
-          break;
-        }
-      }
-
-      textBeforeWrap = textBeforeWrap.length
-        ? `${textBeforeWrap} ${token}`
-        : `${token}`;
-      el.textContent = textBeforeWrap;
-    } */
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,6 +372,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -559,6 +563,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"


### PR DESCRIPTION
The use of `for..of` was giving trouble with browser compatibility. Instead of trying to add `babel-polyfill` for just a simple loop, I switched to:

- a good old `for(;;)` to loop over the `NodeList` returned by `document.querySelectorAll()`
- a call to `reduce` to operate on the string tokens that are part of the string to ellipsize.

Fixes #6 