### PR TITLE
Added resize handling for multiple calls with responsive options (optimized with debouncing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Name | Type |  Default | Description
 ---- | ---- |  ------- | -----------
 replaceStr | string | `'...'` | The string that substituted following the trucated string.
 responsive | boolean | `false` | If true, the method is re-called on resize event, so the number of rows is preserved.
+debounceDelay | integer | `250` | If `responsive` option is set, it's the delay value for resizing events debouncing.
 
 ### Import
 Ellipsed is provided as a UMD module.

--- a/example/index.js
+++ b/example/index.js
@@ -22,25 +22,30 @@ function getResponsive() {
 
 function oneRow() {
   reset();
-  ellipsis('.text p', 1, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.aaa', 1, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 2, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function twoRows() {
   reset();
-  ellipsis('.text p', 2, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.aaa', 2, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 3, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function threeRows() {
   reset();
-  ellipsis('.text p', 3, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.aaa', 3, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 4, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function fourRows() {
   reset();
-  ellipsis('.text p', 4, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.aaa', 4, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 5, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function fiveRows() {
   reset();
-  ellipsis('.text p', 5, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.aaa', 5, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 6, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }

--- a/example/index.js
+++ b/example/index.js
@@ -23,29 +23,29 @@ function getResponsive() {
 function oneRow() {
   reset();
   ellipsis('.text p.aaa', 1, { replaceStr: getReplaceStr(), responsive: getResponsive() });
-  ellipsis('.text p.lorem-ipsum', 2, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 1, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function twoRows() {
   reset();
   ellipsis('.text p.aaa', 2, { replaceStr: getReplaceStr(), responsive: getResponsive() });
-  ellipsis('.text p.lorem-ipsum', 3, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 2, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function threeRows() {
   reset();
   ellipsis('.text p.aaa', 3, { replaceStr: getReplaceStr(), responsive: getResponsive() });
-  ellipsis('.text p.lorem-ipsum', 4, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 3, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function fourRows() {
   reset();
   ellipsis('.text p.aaa', 4, { replaceStr: getReplaceStr(), responsive: getResponsive() });
-  ellipsis('.text p.lorem-ipsum', 5, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 4, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }
 
 function fiveRows() {
   reset();
   ellipsis('.text p.aaa', 5, { replaceStr: getReplaceStr(), responsive: getResponsive() });
-  ellipsis('.text p.lorem-ipsum', 6, { replaceStr: getReplaceStr(), responsive: getResponsive() });
+  ellipsis('.text p.lorem-ipsum', 5, { replaceStr: getReplaceStr(), responsive: getResponsive() });
 }

--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
             <h1>Ellipsed Text Testing</h1>
             <div class="tests">
                 <div class="text">
-                    <p>
+                    <p class="aaa">
                     A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
                     </p>
                 </div>
                 <div class="text">
-                    <p>
+                    <p class="lorem-ipsum">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis lorem ut libero malesuada feugiat. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Pellentesque in ipsum id orci porta dapibus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed porttitor lectus nibh. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     </p>
                 </div>

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -130,11 +130,6 @@
         clearTimeout(resizeTimeout);
         resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
       });
-
-      window.addEventListener('orientationchange', function() {
-        clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
-      });
     }
   }
 

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -113,14 +113,15 @@
       });
     }
 
-    window.onresize = function() {
+    // window.onresize = () => {
+    window.addEventListener('resize', function() {
       for (var _i = 0; _i < elements.length; _i++) {
         var _el = elements[_i];
         _el.textContent = originalTexts[_i];
       }
 
       ellipsis(selector, rows, options);
-    };
+    });
   }
 
   exports.ellipsis = ellipsis;

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -88,6 +88,7 @@
     var defaultOptions = {
       replaceStr: '...',
       responsive: false,
+      debounceDelay: 250,
     };
 
     var opts = _extends({}, defaultOptions, options);
@@ -113,15 +114,28 @@
       });
     }
 
-    // window.onresize = () => {
-    window.addEventListener('resize', function() {
-      for (var _i = 0; _i < elements.length; _i++) {
-        var _el = elements[_i];
-        _el.textContent = originalTexts[_i];
-      }
+    if (opts.responsive) {
+      var resizeTimeout = false;
 
-      ellipsis(selector, rows, options);
-    });
+      var resizeHandler = function resizeHandler() {
+        for (var _i = 0; _i < elements.length; _i++) {
+          var _el = elements[_i];
+          _el.textContent = originalTexts[_i];
+        }
+
+        ellipsis(selector, rows, options);
+      };
+
+      window.addEventListener('resize', function() {
+        clearTimeout(resizeTimeout);
+        resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
+      });
+
+      window.addEventListener('orientationchange', function() {
+        clearTimeout(resizeTimeout);
+        resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
+      });
+    }
   }
 
   exports.ellipsis = ellipsis;

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -43,6 +43,7 @@ function ellipsis(selector = '', rows = 1, options) {
   let defaultOptions = {
     replaceStr: '...',
     responsive: false,
+    debounceDelay: 250,
   };
 
   let opts = { ...defaultOptions, ...options };
@@ -68,15 +69,28 @@ function ellipsis(selector = '', rows = 1, options) {
     });
   }
 
-  // window.onresize = () => {
-  window.addEventListener('resize', () => {
-    for (let i = 0; i < elements.length; i++) {
-      const el = elements[i];
-      el.textContent = originalTexts[i];
-    }
+  if (opts.responsive) {
+    let resizeTimeout = false;
 
-    ellipsis(selector, rows, options);
-  });
+    const resizeHandler = () => {
+      for (let i = 0; i < elements.length; i++) {
+        const el = elements[i];
+        el.textContent = originalTexts[i];
+      }
+
+      ellipsis(selector, rows, options);
+    };
+
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
+    });
+
+    window.addEventListener('orientationchange', () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
+    });
+  }
 }
 
 export { ellipsis };

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -85,11 +85,6 @@ function ellipsis(selector = '', rows = 1, options) {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
     });
-
-    window.addEventListener('orientationchange', () => {
-      clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
-    });
   }
 }
 

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -68,14 +68,15 @@ function ellipsis(selector = '', rows = 1, options) {
     });
   }
 
-  window.onresize = () => {
+  // window.onresize = () => {
+  window.addEventListener('resize', () => {
     for (let i = 0; i < elements.length; i++) {
       const el = elements[i];
       el.textContent = originalTexts[i];
     }
 
     ellipsis(selector, rows, options);
-  };
+  });
 }
 
 export { ellipsis };


### PR DESCRIPTION
I'm resolving issue #22.

Calling ellipsis - for example - two times with two different selectors, it will handle text even on resize correctly on both node elements.

I also optimized for performance the resize event handling to avoid tons of calls when resizing (while working it freezed): following suggestions well explained [here](http://bencentra.com/code/2015/02/27/optimizing-window-resize.html) I implemented a debouncing system similar to the [underscore.js](https://github.com/jashkenas/underscore/blob/master/underscore.js#L880) one.