### PR TITLE
Improved handling of responsive option

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,17 @@
 var ellipsis = window.ellipsed.ellipsis;
 var disableResponsive = window.ellipsed.disableResponsive;
 
+var globalState = {
+  lastEllipsis: null,
+};
+
+function setLastEllipsis(state, lastEllipsis) {
+  if (typeof lastEllipsis !== 'number' || !state) {
+    return;
+  }
+  state.lastEllipsis = lastEllipsis;
+}
+
 function getReplaceStr() {
   return document.querySelector('.replace-str-input').value;
 }
@@ -14,9 +25,11 @@ var resizeListenerLorem;
 
 function ellipsize(rows) {
   reset(resizeListenerAaa, resizeListenerLorem);
+  var replaceStr = getReplaceStr();
   var responsive = getResponsive();
-  resizeListenerAaa = ellipsis('.text p.aaa', rows, { replaceStr: getReplaceStr(), responsive: responsive });
-  resizeListenerLorem = ellipsis('.text p.lorem-ipsum', rows, { replaceStr: getReplaceStr(), responsive: responsive });
+  resizeListenerAaa = ellipsis('.text p.aaa', rows, { replaceStr: replaceStr, responsive: responsive });
+  resizeListenerLorem = ellipsis('.text p.lorem-ipsum', rows, { replaceStr: replaceStr, responsive: responsive });
+  setLastEllipsis(globalState, rows);
 }
 
 function clearEllipsis(resizeListenerAaa, resizeListenerLorem) {
@@ -65,7 +78,7 @@ function fiveRows() {
 }
 document.getElementById('five-rows').addEventListener('click', fiveRows);
 
-function responsiveListener(ev) {
-  !ev.currentTarget.checked && clearEllipsis(resizeListenerAaa, resizeListenerLorem);
+function responsiveListener() {
+  ellipsize(globalState.lastEllipsis);
 }
 document.getElementById('responsive-input').addEventListener('change', responsiveListener);

--- a/example/index.js
+++ b/example/index.js
@@ -1,16 +1,5 @@
 var ellipsis = window.ellipsed.ellipsis;
-
-function reset() {
-  var elements = document.querySelectorAll('.text p');
-  var aaa = elements[0];
-  var loremIpsum = elements[1];
-
-  aaa.innerText =
-    'A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a';
-
-  loremIpsum.innerText =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis lorem ut libero malesuada feugiat. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Pellentesque in ipsum id orci porta dapibus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed porttitor lectus nibh. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
-}
+var disableResponsive = window.ellipsed.disableResponsive;
 
 function getReplaceStr() {
   return document.querySelector('.replace-str-input').value;
@@ -20,14 +9,35 @@ function getResponsive() {
   return document.querySelector('input#responsive-input').checked;
 }
 
+var resizeListenerAaa;
+var resizeListenerLorem;
+
 function ellipsize(rows) {
-  reset();
+  reset(resizeListenerAaa, resizeListenerLorem);
   var responsive = getResponsive();
-  ellipsis('.text p.aaa', rows, { replaceStr: getReplaceStr(), responsive: responsive });
-  ellipsis('.text p.lorem-ipsum', rows, { replaceStr: getReplaceStr(), responsive: responsive });
-  if (responsive) {
-    didEllipsize = true;
+  resizeListenerAaa = ellipsis('.text p.aaa', rows, { replaceStr: getReplaceStr(), responsive: responsive });
+  resizeListenerLorem = ellipsis('.text p.lorem-ipsum', rows, { replaceStr: getReplaceStr(), responsive: responsive });
+}
+
+function clearEllipsis(resizeListenerAaa, resizeListenerLorem) {
+  if (typeof resizeListenerAaa !== 'undefined' && typeof resizeListenerLorem !== 'undefined') {
+    disableResponsive(resizeListenerAaa);
+    disableResponsive(resizeListenerLorem);
   }
+}
+
+function reset(resizeListenerAaa, resizeListenerLorem) {
+  var elements = document.querySelectorAll('.text p');
+  var aaa = elements[0];
+  var loremIpsum = elements[1];
+
+  aaa.innerText =
+    'A a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a';
+
+  loremIpsum.innerText =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla quis lorem ut libero malesuada feugiat. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Pellentesque in ipsum id orci porta dapibus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed porttitor lectus nibh. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+
+  clearEllipsis(resizeListenerAaa, resizeListenerLorem);
 }
 
 function oneRow() {
@@ -55,9 +65,7 @@ function fiveRows() {
 }
 document.getElementById('five-rows').addEventListener('click', fiveRows);
 
-var didEllipsize = false;
-
-function responsiveListener() {
-  didEllipsize && window.location.reload();
+function responsiveListener(ev) {
+  !ev.currentTarget.checked && clearEllipsis(resizeListenerAaa, resizeListenerLorem);
 }
 document.getElementById('responsive-input').addEventListener('change', responsiveListener);

--- a/lib/ellipsed.js
+++ b/lib/ellipsed.js
@@ -121,16 +121,24 @@
         for (var _i = 0; _i < elements.length; _i++) {
           elements[_i].textContent = originalTexts[_i];
         }
-
         ellipsis(selector, rows, _extends({}, options, { responsive: false }));
       };
 
-      window.addEventListener('resize', function() {
+      var resizeListener = function resizeListener() {
         clearTimeout(resizeTimeout);
         resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
-      });
+      };
+
+      window.addEventListener('resize', resizeListener);
+
+      return resizeListener;
     }
   }
 
+  function disableResponsive(listener) {
+    window.removeEventListener('resize', listener);
+  }
+
+  exports.disableResponsive = disableResponsive;
   exports.ellipsis = ellipsis;
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ellipsed",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JavaScript library for multilined text ellipsis",
   "licence": "MIT",
   "homepage": "https://nzambello.github.io/ellipsed/",

--- a/src/ellipsed.js
+++ b/src/ellipsed.js
@@ -76,15 +76,22 @@ function ellipsis(selector = '', rows = 1, options = {}) {
       for (let i = 0; i < elements.length; i++) {
         elements[i].textContent = originalTexts[i];
       }
-
       ellipsis(selector, rows, { ...options, responsive: false });
     };
 
-    window.addEventListener('resize', () => {
+    const resizeListener = () => {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(resizeHandler, opts.debounceDelay);
-    });
+    };
+
+    window.addEventListener('resize', resizeListener);
+
+    return resizeListener;
   }
 }
 
-export { ellipsis };
+function disableResponsive(listener) {
+  window.removeEventListener('resize', listener);
+}
+
+export { disableResponsive, ellipsis };


### PR DESCRIPTION
The ellipsis function is now returning a reference to the added resize listener and a function that removes a given listener.

More specifically, when in responsive mode, ellipsis returns a reference to the added listener. Calling the new `disableResponsive` function on the listener will remove it, eventually removing the whole responsive effect.

This is still a work in progress PR, so it's not ready for merging. If you like this proposal we can work on a README improvement to be added to this PR. The example, on the other hand, is already using the new feature, and is not reloading the page anymore when responsive is disabled.

This is an attempt to fix #27 in a proper way.